### PR TITLE
ITF Barcodes work properly, changed window.plugins to cordova.plugins, Added QuartzCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A full example could be:
 ```
 
 ## Encoding a Barcode ##
-The plugin creates the object `window.plugins.barcodeScanner` with the method `encode(type, data, success, fail)`. 
+The plugin creates the object `cordova.plugins.barcodeScanner` with the method `encode(type, data, success, fail)`. 
 Supported encoding types:
 
 * TEXT_TYPE

--- a/plugin.xml
+++ b/plugin.xml
@@ -35,6 +35,7 @@
         <framework src="AVFoundation.framework" />
         <framework src="AssetsLibrary.framework" />
         <framework src="CoreVideo.framework" />
+        <framework src="QuartzCore.framework" />
     </platform>
 
     <!-- android -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="com.phonegap.plugins.barcodescanner"
-    version="1.0.1">
+    id="il.co.pnc.plugins.barcodescanner"
+    version="1.0.2">
 
     <name>BarcodeScanner</name>
     <description>Scans Barcodes.</description>

--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -399,7 +399,10 @@ parentViewController:(UIViewController*)parentViewController
         decodeHints.addFormat(BarcodeFormat_EAN_13);
         decodeHints.addFormat(BarcodeFormat_CODE_128);
         decodeHints.addFormat(BarcodeFormat_CODE_39);
-        //            decodeHints.addFormat(BarcodeFormat_ITF);   causing crashes
+        
+        // 2014-06-08 - Was commented out till now. Was marked as "causing crashes".
+        // However, after testing this - it seems to work perfectly fine on iOS devices, using PhoneGap 3+
+        decodeHints.addFormat(BarcodeFormat_ITF);
         
         // here's the meat of the decode process
         Ref<LuminanceSource>   luminanceSource   ([self getLuminanceSourceFromSample: sampleBuffer imageBytes:&imageBytes]);


### PR DESCRIPTION
- Add missing iOS framework "QuartzCore" to plugin.xml
- window.plugins > changed with cordova.plugins
- ITF barcodes work properly.
