### PR TITLE
Fixing code sample in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ Supported encoding types:
 ```
 A full example could be:
 
-   cordova.plugins.barcodeScanner.encode(BarcodeScanner.Encode.TEXT_TYPE, "http://www.nytimes.com", function(success) {
+   var barcodeScanner = cordova.plugins.barcodeScanner;
+   barcodeScanner.encode(barcodeScanner.Encode.TEXT_TYPE, "http://www.nytimes.com", function(success) {
             alert("encode success: " + success);
           }, function(fail) {
             alert("encoding failed: " + fail);


### PR DESCRIPTION
I have faced the same issue against cordova-3.6.3 - https://github.com/wildabeast/BarcodeScanner/issues/76
Basically, it's reference error cause BarcodeScanner is not defined. Assuming that I propose to update code sample in the README.MD to avoid misleading.
